### PR TITLE
Fix -l flag bug

### DIFF
--- a/src/main.m
+++ b/src/main.m
@@ -90,6 +90,7 @@ int main(int argc, const char * argv[]) { @autoreleasepool {
             // Set language (i.e. locale) for speech recognition
             case 'l':
                 language = @(optarg);
+                break;
             
             // Input filename ("-" for stdin)
             case 'i':


### PR DESCRIPTION
A very modest fix. A `break` statement was missing from the command line argument parsing code.

This fixes the bug probably referenced in #2 and #10